### PR TITLE
changed Comparator to use EObject names as ids

### DIFF
--- a/utils/Comparator/build.gradle
+++ b/utils/Comparator/build.gradle
@@ -3,8 +3,8 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
-sourceCompatibility = "11"
-targetCompatibility = "11"
+sourceCompatibility = "17"
+targetCompatibility = "17"
 
 repositories {
     mavenCentral()
@@ -24,6 +24,9 @@ dependencies {
 
     implementation 'io.github.atlresearch:emfmodelfuzzer:+'
     implementation 'io.github.atlresearch.ttc2023:solutiondriver:+'
+
+    // to be able to specify custom localIdGetters
+    implementation "org.eclipse.xtend:org.eclipse.xtend.lib:2.25.0"
 }
 
 application {

--- a/utils/Comparator/src/main/java/atl/research/Comparator.java
+++ b/utils/Comparator/src/main/java/atl/research/Comparator.java
@@ -1,5 +1,8 @@
 package atl.research;
 
+import java.util.HashMap;
+
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
@@ -48,7 +51,11 @@ public class Comparator {
         final SimpleEMFModelComparator comparator = new SimpleEMFModelComparator();
 
         final StringBuffer messageBuffer = new StringBuffer();
-        comparator.compare(expectedResource, currentResource, messageBuffer);
+        comparator.compare("/contents", expectedResource.getContents(), currentResource.getContents(), new HashMap<>(), messageBuffer, (index, value) ->
+		value instanceof EObject eo
+		?	eo.eGet(eo.eClass().getEStructuralFeature("name"))
+		:	value
+	);
 
         if (messageBuffer.length() > 0) {
             System.err.println(messageBuffer.toString());


### PR DESCRIPTION
This Comparator change proposal makes it use EObject names as local identifiers for the comparison. This will not work for every metamodel, but should work for the Relational metamodel, in which all EClasses have names.
This follows the discussion in issue #25.