### PR TITLE
improved Comparator to use children names when name is null

### DIFF
--- a/utils/Comparator/src/main/java/atl/research/Comparator.java
+++ b/utils/Comparator/src/main/java/atl/research/Comparator.java
@@ -51,11 +51,26 @@ public class Comparator {
         final SimpleEMFModelComparator comparator = new SimpleEMFModelComparator();
 
         final StringBuffer messageBuffer = new StringBuffer();
-        comparator.compare("/contents", expectedResource.getContents(), currentResource.getContents(), new HashMap<>(), messageBuffer, (index, value) ->
-		value instanceof EObject eo
-		?	eo.eGet(eo.eClass().getEStructuralFeature("name"))
-		:	value
-	);
+        comparator.compare("/contents", expectedResource.getContents(), currentResource.getContents(), new HashMap<>(), messageBuffer, (index, value) -> {
+		if(value instanceof EObject eo) {
+			Object ret = eo.eGet(eo.eClass().getEStructuralFeature("name"));
+			if(ret == null && !eo.eContents().isEmpty()) {
+				ret = "";
+				for(EObject eoc : eo.eContents()) {
+					Object name = (String)eoc.eGet(eoc.eClass().getEStructuralFeature("name"));
+					if(name != null) {
+						if(!ret.equals("")) {
+							ret += ",";
+						}
+						ret += "" + name;
+					}
+				}
+			}
+			return ret;
+		} else {
+			return value;
+		}
+	});
 
         if (messageBuffer.length() > 0) {
             System.err.println(messageBuffer.toString());


### PR DESCRIPTION
When several tables have a null name, the previously used localIdGetter would make comparison fail. This new version tries to work around this issue by using children (i.e., column) names.

Like the previous localIdGetter, this is still specific to the Relational metamodel, and is still fragile. However, it might be enough for this case.

The best solution I know of would be to leverage trace links (see issue #25). However, this would make it necessary for all submissions to serialize them, which is not currently considered.