### PR TITLE
Fix C# solutions

### DIFF
--- a/solutions/csharp_cp/CSharpClassToRelational.cs
+++ b/solutions/csharp_cp/CSharpClassToRelational.cs
@@ -46,6 +46,13 @@ namespace HSRM.TTC2023.ClassToRelational
                 // Change_Propagation 
                 targetCollection.Remove(target);
             }
+            if (original is IClass cl)
+            {
+                foreach (var att in cl.Attr.Where(a => a.MultiValued))
+                {
+                    targetCollection.Remove((T)_attributeTables[att]);
+                }
+            }
         }
 
         // Transformation 
@@ -223,7 +230,7 @@ namespace HSRM.TTC2023.ClassToRelational
                 // Change_Propagation 
                 var att = sender as IAttribute;
                 // Change_Propagation 
-                if (att!.MultiValued)
+                if (!att!.MultiValued)
                 {
                     // Change_Propagation 
                     table!.Col.Add((IColumn)TraceOrTransform(att)!);

--- a/solutions/csharp_cp/CSharpClassToRelational.cs
+++ b/solutions/csharp_cp/CSharpClassToRelational.cs
@@ -375,9 +375,9 @@ namespace HSRM.TTC2023.ClassToRelational
             void OnNameChanged(object? sender, ValueChangedEventArgs? e)
             {
                 // Transformation 
-                table.Name = attribute.Owner.Name + "_" + attribute.Name;
+                table.Name = attribute.Owner?.Name + "_" + attribute.Name;
                 // Transformation 
-                key.Name = attribute.Owner.Name.ToCamelCase() + "Id";
+                key.Name = attribute.Owner?.Name.ToCamelCase() + "Id";
             }
             // Helper 
             OnNameChanged(null, null);

--- a/solutions/csharp_cp/CSharpClassToRelational.cs
+++ b/solutions/csharp_cp/CSharpClassToRelational.cs
@@ -239,7 +239,7 @@ namespace HSRM.TTC2023.ClassToRelational
             foreach (var attr in @class.Attr)
             {
                 // Model Traversal 
-                if (attr.MultiValued)
+                if (!attr.MultiValued)
                 {
                     //  Transformation 
                     table.Col.Add((IColumn)TraceOrTransform(attr)!);

--- a/utils/SolutionDriverNet/Metamodel/Changes/AddToRoot.cs
+++ b/utils/SolutionDriverNet/Metamodel/Changes/AddToRoot.cs
@@ -75,7 +75,10 @@ namespace HSRM.TTC2023.ClassToRelational.Changes
                     this._newObject = value;
                     if ((old != null))
                     {
-                        old.Parent = null;
+                        if ((old.Parent == this))
+                        {
+                            old.Parent = null;
+                        }
                         old.ParentChanged -= this.OnResetNewObject;
                     }
                     if ((value != null))


### PR DESCRIPTION
The C# solutions still fail for scale1 because the AttributePropertyChange references a reference instead of an attribute, all other tests pass